### PR TITLE
Add collaborative teamGoal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ By default, the program will use the profiles specified in `settings.js`. You ca
 
 Some of the node modules that we depend on have bugs in them. To add a patch, change your local node module file and run `npx patch-package [package-name]`
 
+## Collaborative Commands
+
+Use `!teamGoal("Build a house")` to broadcast a shared goal to all bots online. Each agent will collaborate and divide the workload automatically.
+
 ## Citation:
 
 ```


### PR DESCRIPTION
## Summary
- enable actions.js to access server proxy and executeCommand
- add !teamGoal action to broadcast goal to all bots
- document collaborative commands in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b4e4c0b508326a5ad4fcd63006c0d